### PR TITLE
fix: ユーザIDの桁数が10以外のメンションに対応する

### DIFF
--- a/libs/message.mts
+++ b/libs/message.mts
@@ -476,7 +476,7 @@ export class MessageClient {
       }
 
     // Replace mention
-    const mentions = newContent.match(/<@U[A-Z0-9]{10}>/g)
+    const mentions = newContent.match(/<@U[A-Z0-9]+?>/g)
     if (mentions?.length) {
       const userIds = mentions.map((mention) => mention.replace(/<@|>/g, ''))
       for (const userId of userIds) {


### PR DESCRIPTION
Fixes #133 

ユーザへのメンション（`@<UXXXXXX>`）のパースの際、U以下の桁数が10桁でないIDに対応するようにします。

現在は10桁のユーザIDが最大長のように思われますが、将来11桁以上のものが割り振られる可能性を考慮し、桁数を勘案しないように実装しています。