### PR TITLE
fix: embedsが10件を超えないよう制限する

### DIFF
--- a/libs/message.mts
+++ b/libs/message.mts
@@ -282,6 +282,12 @@ export class MessageClient {
         ...urlEmbeds,
       ]
 
+      // If embeds length is over 10, truncate it
+      if (embeds.length > 10) {
+        // ToDo: Show some warnings?
+        embeds.length = 10
+      }
+
       // Deploy message
       let messageManager: MessageManager | undefined = undefined
       if (message.isReplyed && message.threadId) {


### PR DESCRIPTION
Fixes #134 

画像やリンクが多数含まれ、Discord APIに渡す`embeds`の件数が10を超えた際にAPIからエラーが返されるのを防ぐため、10件を超えないよう制約します。

ひとまずの措置としてサイレントに切り捨てるように実装していますが、何らかの警告を出したり、情報が失われないようにすべきかもしれません。