### PR TITLE
fix: URLの検出に最短マッチを使用する

### DIFF
--- a/libs/message.mts
+++ b/libs/message.mts
@@ -507,7 +507,7 @@ export class MessageClient {
 
     // Replace String with url
     const newUrls: Url[] = []
-    const stringWithUrls = newContent.match(/<http[s]?:\/\/.*\|.*>/g)
+    const stringWithUrls = newContent.match(/<https?:\/\/.+?\|.+?>/g)
     if (stringWithUrls?.length) {
       for (const stringWithUrl of stringWithUrls) {
         const name = stringWithUrl


### PR DESCRIPTION
Fixes #135 

複数のURLが含まれるメッセージをmigrateする際、URLごとの範囲を誤検出する問題を修正します。最短マッチを使用し、最も短い範囲をひとつのURLとするように変更します。